### PR TITLE
don't set bearer token for non-hypermode hosted graphs

### DIFF
--- a/client/src/components/ServerConnectionModal.js
+++ b/client/src/components/ServerConnectionModal.js
@@ -222,7 +222,7 @@ export default function ServerConnectionModal() {
             }}
         >
             <Form.Group controlId="serverUrlInput">
-                <Form.Label>Dgraph Conn String:</Form.Label>
+                <Form.Label>Dgraph Connection String:</Form.Label>
                 <Form.Control
                     type="text"
                     placeholder="https://dgraph.example.com:port"

--- a/client/src/reducers/connection.js
+++ b/client/src/reducers/connection.js
@@ -51,6 +51,9 @@ import {
     Unknown,
 } from "lib/constants";
 
+const HYPERMODE_HOST_DOMAIN = "hypermode.host";
+const HYPERMODE_STAGE_HOST_DOMAIN = "hypermode-stage.host";
+
 const assert = (test, message = "No message") => {
     if (!test) {
         throw new Error("Assertion Failed: " + message);
@@ -202,7 +205,12 @@ export default (state = defaultState, action) =>
                 const newActiveServer = draft.serverHistory[0];
                 newActiveServer.slashApiKey = action.slashApiKey;
                 setCurrentServerUrl(newActiveServer.url);
-                setCurrentServerSlashApiKey(newActiveServer.slashApiKey);
+                if (
+                    action.url.endsWith(HYPERMODE_HOST_DOMAIN) ||
+                    action.url.endsWith(HYPERMODE_STAGE_HOST_DOMAIN)
+                ) {
+                    setCurrentServerSlashApiKey(newActiveServer.slashApiKey);
+                }
                 break;
             case SET_AUTH_TOKEN:
                 assert(action.url, "This action requires url " + action.type);


### PR DESCRIPTION
**Description**

Please explain the changes you made here.

**Checklist**

- [ ] Code compiles correctly and linting passes locally
- [ ] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [ ] Tests added for new functionality, or regression tests for bug fixes added as applicable
- [ ] For public APIs, new features, etc., PR on
      [docs repo](https://github.com/dgraph-io/dgraph-docs) staged and linked here

**Instructions**

- The PR title should follow the [Conventional Commits](https://www.conventionalcommits.org/)
  syntax, leading with `fix:`, `feat:`, `chore:`, `ci:`, etc.
- The description should briefly explain what the PR is about. In the case of a bugfix, describe or
  link to the bug.
- In the checklist section, check the boxes in that are applicable, using `[x]` syntax. If not
  applicable, remove the entire line. Only leave the box unchecked if you intend to come back and
  check the box later.
- Delete the `Instructions` line and everything below it, to indicate you have read and are
  following these instructions. 🙂

Thank you for your contribution to Dgraph!
