### PR TITLE
fix: ratel editor freezing when typing

### DIFF
--- a/client/src/containers/Editor.js
+++ b/client/src/containers/Editor.js
@@ -32,11 +32,6 @@ export default function Editor({
   const [keywords, setKeywords] = useState([])
 
   const lastSetValueRef = useRef('')
-  const onUpdateQueryRef = useRef(onUpdateQuery)
-
-  useEffect(() => {
-    onUpdateQueryRef.current = onUpdateQuery
-  }, [onUpdateQuery])
   const isSettingContent = useRef(false)
 
   const allState = useSelector((state) => state)
@@ -173,26 +168,24 @@ export default function Editor({
       } else if (!isJsonValue) {
         editorInstance.setOption('mode', 'graphql')
       }
-      onUpdateQueryRef.current?.(value)
+
+      if (onUpdateQuery) {
+        onUpdateQuery(value)
+      }
     }
   
     editorInstance.on('change', onChangeHandler)
-    return () => {
-      editorInstance.off('change', onChangeHandler)
-    }
-  }, [])
+    return () => editorInstance.off('change', onChangeHandler)
+  }, [onUpdateQuery])
   
 
   useEditorEffect(() => {
-    const onKeyDownHandler = (cm, event) => {
+    editorInstance.on('keydown', (cm, event) => {
       const code = event.keyCode
       if (!event.ctrlKey && code >= 65 && code <= 90) {
         CodeMirror.commands.autocomplete(cm)
       }
-    }
-    editorInstance.on('keydown', onKeyDownHandler)
-
-    return () => editorInstance.off('keydown', onKeyDownHandler)
+    })
   }, [])
 
   // Every time query changes

--- a/client/src/containers/Editor.js
+++ b/client/src/containers/Editor.js
@@ -173,7 +173,7 @@ export default function Editor({
         onUpdateQuery(value)
       }
     }
-  
+
     editorInstance.on('change', onChangeHandler)
     return () => editorInstance.off('change', onChangeHandler)
   }, [onUpdateQuery])

--- a/client/src/containers/Editor.js
+++ b/client/src/containers/Editor.js
@@ -177,7 +177,6 @@ export default function Editor({
     editorInstance.on('change', onChangeHandler)
     return () => editorInstance.off('change', onChangeHandler)
   }, [onUpdateQuery])
-  
 
   useEditorEffect(() => {
     editorInstance.on('keydown', (cm, event) => {


### PR DESCRIPTION
**Description**

This PR fixes an infinite loop caused by mutual updates between the editor's onChange handler and the query prop.

Previously, onChange would trigger onUpdateQuery, which updated the query prop.

A useEffect would then detect the new query and update the editor value again which would then retrigger the onChange handler, creating a loop.

Added a stable `isSettingContent` status ref to understand when the query is being updated and to return early from the onchange handler if it's active.

**Checklist**

- [ ] Code compiles correctly and linting passes locally
- [ ] For all _code_ changes, an entry added to the `CHANGELOG.md` file describing and linking to
      this PR
- [ ] Tests added for new functionality, or regression tests for bug fixes added as applicable
- [ ] For public APIs, new features, etc., PR on [docs repo](https://github.com/hypermodeinc/docs)
      staged and linked here
